### PR TITLE
Bail early and avoid warnings on 32 bit Perl builds

### DIFF
--- a/bin/zipdetails
+++ b/bin/zipdetails
@@ -7,6 +7,14 @@
 
 use 5.010; # for unpack "Q<"
 
+BEGIN {
+    if (!eval { pack "Q", 1 }) {
+        warn "zipdetails requires 64 bit integers, ",
+                "this Perl has 32 bit integers.\n";
+        exit(1);
+    }
+}
+
 BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
 use warnings ;


### PR DESCRIPTION
In 03d099661c3d605a52600cac7468ef8f81d4ac49 the U64 class was removed
and zipdetails was made 64 bit only. This causes warnings and test
failures (t/porting/utils.t) on i386 builds of perl core when
IO-Compress 2.105 was merged.
https://github.com/Perl/perl5/pull/19618
    # Failed test 83 - utils/zipdetails compiles at porting/utils.t line 85
    #      got "Integer overflow in hexadecimal number at utils/zipdetails line 1432.
    Integer overflow in hexadecimal number at utils/zipdetails line 2247.
    Integer overflow in hexadecimal number at utils/zipdetails line 2248.
    Integer overflow in hexadecimal number at utils/zipdetails line 2249.
    Integer overflow in hexadecimal number at utils/zipdetails line 2250.
    Integer overflow in hexadecimal number at utils/zipdetails line 2251.
    Integer overflow in hexadecimal number at utils/zipdetails line 2252.
    Integer overflow in hexadecimal number at utils/zipdetails line 2253.
    Integer overflow in hexadecimal number at utils/zipdetails line 2254.
    utils/zipdetails syntax OK
    "
    # expected "utils/zipdetails syntax OK
    "
    t/porting/utils .................................................. FAILED at test 83

The code also makes use of unpack "Q" so it wouldn't work on 32 bit
builds anyway.

This patch adds a check very early in the script to see if the perl supports
pack "Q", and it does not, indicating it is a 32 bit perl, then it bails out.
If the script is run under -c it bails out without a message, and otherwise
it prints out a message, and exits with error code 1.

    $ ./perl -Ilib utils/zipdetails
    zipdetails requires 64 bit integers, this Perl has 32 bit integers.

This alone does not make it pass t/porting/utils.t in Perl core, we need
a corresponding patch to t/porting/utils.t which I will also push.

See https://github.com/Perl/perl5/pull/19618 for the corresponding patch.